### PR TITLE
[TCP-17 TCP-18] FIX: Cache-control for individual newsletters and homepage

### DIFF
--- a/app/newsletter/[slug]/page.tsx
+++ b/app/newsletter/[slug]/page.tsx
@@ -4,9 +4,7 @@ import cx from "clsx";
 import { Suspense } from "react";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { COMPONENTS } from "@lib/mdxComponents";
-import { getHeaders } from "@lib/parsers";
 
-import { dummyArticle } from "@utils/constants/dummyData";
 import { getNewsletter } from "../server-helpers/server-helpers";
 import Image from "next/image";
 
@@ -15,8 +13,8 @@ interface Params {
 }
 
 const Newsletter = async ({ params }: Params) => {
-  const newsletter = await getNewsletter(params.slug);
-  const headers = getHeaders(dummyArticle);
+  const { newsletter, headers } = await getNewsletter(params.slug);
+
   return (
     <main className={cx("mainContent", styles.mainWrapper)}>
       <article className={styles.content}>
@@ -24,7 +22,7 @@ const Newsletter = async ({ params }: Params) => {
         <h1 className={styles.articleTitle}>{newsletter.title}</h1>
         <Suspense fallback={"loading..."}>
           <MDXRemote
-            source={newsletter.content || ""}
+            source={newsletter.content ?? ""}
             components={COMPONENTS}
           />
         </Suspense>

--- a/sanity/constants/templates/content.ts
+++ b/sanity/constants/templates/content.ts
@@ -1,14 +1,18 @@
-export const MARKDOWN_TEMPLATE = `### Community Highlight (optional)
+export const MARKDOWN_TEMPLATE = `## Community Highlight 
+
 Here is where we highlight someone who has either made contributions to the community or has been a very active member in the past month.
 
-This month's community highlight goes to {name}!! 
-List Reason {name} was nominated for this month's community highlight
+This month's community highlight goes to [name]!! 
+List Reason [name] was nominated for this month's community highlight
 
-### In case you missed it
+## In case you missed it
+
 - Here we highlight past events that occurred during the previous month
 
-### For your information
+## For your information
+
 - This is useful information to know about the community
 
-### Tech Insights
+## Tech Insights
+
 -  These are short articles on interesting occurrences within the tech space`;

--- a/sanity/lib/client.ts
+++ b/sanity/lib/client.ts
@@ -2,11 +2,11 @@ import { createClient } from "next-sanity";
 
 import { apiVersion, dataset, projectId } from "../env";
 
-import { Newsletters_Schema } from "@utils/types/zod-schema-types";
+import { IS_PROD } from "@utils/constants";
 
 export const client = createClient({
   projectId,
   dataset,
   apiVersion,
-  useCdn: false, // Set to false if statically generating pages, using ISR or tag-based revalidation
+  useCdn: IS_PROD,
 });


### PR DESCRIPTION
**Overview**: This ticket resolves the issue where once the content is updated within sanity, it does not directly reflect on the newsletter homepage or newsletter page. The ticket imposes a revalidate option for production environments and removes the cache for development environments.

The ticket also resolves the invalid reference type within the Markdown template.

**Related JIRA Ticket** https://techtankto.atlassian.net/browse/TCP-17 https://techtankto.atlassian.net/browse/TCP-18

**Test URL**: http://localhost:3000/newsletter/november-newsletter