### PR TITLE
Fix: emoji incorrectly being displayed within markdown content

### DIFF
--- a/app/newsletter/[slug]/page.tsx
+++ b/app/newsletter/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { getNewsletter } from "../server-helpers/server-helpers";
 import Image from "next/image";
 
 import remarkGfm from "remark-gfm";
+import emoji from "remark-emoji";
 import { format } from "date-fns";
 
 interface Params {
@@ -44,7 +45,11 @@ const NewsletterPage = async ({ params }: Params) => {
             <MDXRemote
               source={newsletter.content ?? ""}
               components={COMPONENTS}
-              options={{ mdxOptions: { remarkPlugins: [remarkGfm] } }}
+              options={{
+                mdxOptions: {
+                  remarkPlugins: [[remarkGfm, { singleTilde: false }], emoji],
+                },
+              }}
             />
           </Suspense>
           <section className={styles.metaData}>

--- a/lib/mdxComponents/elements/HeaderII.tsx
+++ b/lib/mdxComponents/elements/HeaderII.tsx
@@ -4,18 +4,20 @@ interface Props {
   childNodes: any;
 }
 
+const parseID = (node: string | string[]) => {
+  const id = Array.isArray(node) ? node.join("") : node;
+
+  return id
+    .toLowerCase()
+    .replace(/:([a-zA-Z0-9_#]+):/, "")
+    .replace(/[^a-z0-9 ]/g, "")
+    .trim()
+    .replace(/[ ]/g, "-");
+};
+
 const HeaderII = ({ childNodes }: Props) => {
-  return (
-    <h2
-      id={childNodes.children
-        .toLowerCase()
-        .replace(/[^a-z0-9 ]/g, "")
-        .replace(/[ ]/g, "-")
-        .trim()}
-      className={styles.headerII}
-      {...childNodes}
-    ></h2>
-  );
+  const id = parseID(childNodes.children);
+  return <h2 id={id} className={styles.headerII} {...childNodes} />;
 };
 
 export default HeaderII;

--- a/lib/mdxComponents/elements/HeaderIII.tsx
+++ b/lib/mdxComponents/elements/HeaderIII.tsx
@@ -4,18 +4,21 @@ interface Props {
   childNodes: any;
 }
 
+const parseID = (node: string | string[]) => {
+  const id = Array.isArray(node) ? node.join("") : node;
+
+  return id
+    .toLowerCase()
+    .replace(/:([a-zA-Z0-9_#]+):/, "")
+    .replace(/[^a-z0-9 ]/g, "")
+    .trim()
+    .replace(/[ ]/g, "-");
+};
+
 const HeaderIII = ({ childNodes }: Props) => {
-  return (
-    <h3
-      id={childNodes.children
-        .toLowerCase()
-        .replace(/[^a-z0-9 ]/g, "")
-        .replace(/[ ]/g, "-")
-        .trim()}
-      className={styles.headerIII}
-      {...childNodes}
-    ></h3>
-  );
+  const id = parseID(childNodes.children);
+
+  return <h3 id={id} className={styles.headerIII} {...childNodes} />;
 };
 
 export default HeaderIII;

--- a/lib/parsers/getHeaders.ts
+++ b/lib/parsers/getHeaders.ts
@@ -4,15 +4,20 @@ export const getHeaders = (fileString: string) => {
   const headingLst = fileString.match(regex) || [];
 
   const formattedHeading = headingLst.map((heading) => {
-    const process = heading.replace(/#/g, "").trim().toLowerCase();
+    const process = heading
+      .replace(/#/g, "")
+      .replace(/:([a-zA-Z0-9_#]+):/g, "")
+      .trim()
+      .toLowerCase();
     const level = heading.match(/#/g)?.length || 1;
 
     return {
       heading: process,
       slug: process
-        .trim()
         .toLowerCase()
+        .replace(/:([a-zA-Z0-9_#]+):/g, "")
         .replace(/[^a-z0-9 ]/g, "")
+        .trim()
         .replace(/[ ]/g, "-"),
       level: level,
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-icons": "^5.3.0",
+        "remark-emoji": "^5.0.1",
         "remark-gfm": "^4.0.0",
         "sanity": "^3.58.0",
         "sanity-plugin-cloudinary": "^1.1.3",
@@ -4399,6 +4400,17 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.2.2.tgz",
       "integrity": "sha512-TMp15K+GGYrWlZM8+Lnj9EaHEFmOen0WJBrfa17hF7taDOYthuPPV0GWzfd/9iMij0akS/8Yw2ikquH7uVi/fg=="
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -6083,6 +6095,14 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -7345,6 +7365,20 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="
+    },
+    "node_modules/emoticon": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/emoticon/-/emoticon-4.1.0.tgz",
+      "integrity": "sha512-VWZfnxqwNcc51hIy/sbOdEem6D+cVtpPzEEtVAFdaas30+1dgkyaOQ4sQ6Bp0tOMqWO1v+HQfYaoodOkdhK6SQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -12299,6 +12333,20 @@
         "styled-components": "^6.1"
       }
     },
+    "node_modules/node-emoji": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
+      "integrity": "sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/node-html-parser": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
@@ -13904,6 +13952,21 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/remark-emoji": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-5.0.1.tgz",
+      "integrity": "sha512-QCqTSvcZ65Ym+P+VyBKd4JfJfh7icMl7cIOGVmPMzWkDtdD8pQ0nQG7yxGolVIiMzSx90EZ7SwNiVpYpfTxn7w==",
+      "dependencies": {
+        "@types/mdast": "^4.0.4",
+        "emoticon": "^4.0.1",
+        "mdast-util-find-and-replace": "^3.0.1",
+        "node-emoji": "^2.1.3",
+        "unified": "^11.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.0.tgz",
@@ -15214,6 +15277,17 @@
         "node": ">= 10"
       }
     },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -16391,6 +16465,14 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
       "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
       "engines": {
         "node": ">=4"
       }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^5.3.0",
+    "remark-emoji": "^5.0.1",
     "remark-gfm": "^4.0.0",
     "sanity": "^3.58.0",
     "sanity-plugin-cloudinary": "^1.1.3",


### PR DESCRIPTION
**Overview** This ticket resolves the issue where emojis written in markdown syntax were not being displayed as emojis in the newsletter. 

eg/ `:smile:` was not being displayed as 😄 

**Related JIRA Ticket** https://techtankto.atlassian.net/browse/TCP-28

**Test URL**: http://localhost:3000/newsletter/august-newsletter
